### PR TITLE
Rename run to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ my_block = {
 };
 ```
 
-A block basically stores a block of code inside it, which can then be executed on cue, using the `run $block` builtin:
+A block basically stores a block of code inside it, which can then be executed on cue, using the `do $block` builtin:
 
 ```r
-run $my_block;
+do $my_block;
 ```
 
 This piece of code prints "Hello, world" to the console. Like functions, blocks can recieve arguments:
@@ -171,13 +171,13 @@ This piece of code prints "Hello, world" to the console. Like functions, blocks 
 ```r
 add = { |a, b| -> a + b; };
 
-run $add with [3, 10];
+do $add with [3, 10];
 ```
 
 This block, called `add`, takes two arguments: `a`, and `b`. It then returns the sum of them. As you can see, to run a
-block with arguments, you use the `run $block with $args` builtin, providing the arguments as an array.
+block with arguments, you use the `do $block with $args` builtin, providing the arguments as an array.
 
-An interesting note is that both `run $block` and `run $block with $args` are both defined as normal functions.
+An interesting note is that both `do $block` and `do $block with $args` are both defined as normal functions.
 
 Blocks are also used in some functions in the standard library:
 
@@ -357,4 +357,4 @@ There are loads of things to do. Heres a list for you:
  - Maybe add a regex literal
  - Add raw strings
  - Add a better way of doing string interpolation, maybe `"hello {{x}} {{y + x}}"?`
- - Rename `run $block` to `do $block`
+ - Rename `do $block` to `do $block`

--- a/README.md
+++ b/README.md
@@ -357,4 +357,3 @@ There are loads of things to do. Heres a list for you:
  - Maybe add a regex literal
  - Add raw strings
  - Add a better way of doing string interpolation, maybe `"hello {{x}} {{y + x}}"?`
- - Rename `do $block` to `do $block`

--- a/examples/basic.pluto
+++ b/examples/basic.pluto
@@ -25,5 +25,5 @@ print (good_numbers + bad_numbers + name);
 say_hi = { print "Hello, world!"; };
 add = { |x, y| -> x + y; };
 
-run $say_hi;
-run $add with (5, 10);
+do $say_hi;
+do $add with (5, 10);

--- a/examples/blocks.pluto
+++ b/examples/blocks.pluto
@@ -2,8 +2,8 @@
 triple = { |x| -> x * 3; };
 
 # you can run a block with the `run $block [with $args]` builtin
-run { print "No arguments!"; };
-six = run $triple with [2];
+do { print "No arguments!"; };
+six = do $triple with [2];
 
 # they are used in a lot of builtins
 squares = map { |x| -> x ** 2; } over (\1 to 11);

--- a/examples/custom-if.pluto
+++ b/examples/custom-if.pluto
@@ -1,8 +1,8 @@
 def if $condition $a else $b {
   if (condition) {
-    run $a;
+    do $a;
   } else {
-    run $b;
+    do $b;
   };
 };
 

--- a/src/builtin_fns.py
+++ b/src/builtin_fns.py
@@ -75,15 +75,15 @@ def input_with_prompt_prompt(args, context):
         return NULL
 
 @arg("block", obj.Block)
-@builtin("run $block")
-def run_block(args, context):
+@builtin("do $block")
+def do_block(args, context):
     block = args["block"]
 
     if type(block) != obj.Block:
-        return err("the $block parameter in `run $block` must be of type <block>")
+        return err("the $block parameter in `do $block` must be of type <block>")
 
     if len(block.params) > 0:
-        return err("since no arguments are provided, $block of `run $block` must have no parameters")
+        return err("since no arguments are provided, $block of `do $block` must have no parameters")
 
     ctx = context.enclose()
     return evaluate(block.body, ctx)
@@ -96,13 +96,16 @@ def _run_block(block, args, context):
 
 @arg("block", obj.Block)
 @arg("args", obj.Collection)
-@builtin("run $block with $args")
-def run_block_with_args(args, context):
+@builtin("do $block with $args")
+def do_block_with_args(args, context):
     block = args["block"]
     b_args = args["args"].get_elements()
 
+    if type(block) != obj.Block:
+        return err("the $block parameter in `do $block with $args` must be of type <block>")
+
     if len(block.params) != len(b_args):
-        return err("the amount of arguments provided in `run $block with $args` should match the number of parameters in the block")
+        return err("the amount of arguments provided in `do $block with $args` should match the number of parameters in the block")
 
     params = [param.value for param in block.params]
     args_dictionary = dict(zip(params, b_args))

--- a/src/builtin_fns.py
+++ b/src/builtin_fns.py
@@ -74,6 +74,12 @@ def input_with_prompt_prompt(args, context):
     except (KeyboardInterrupt, EOFError):
         return NULL
 
+def _run_block(block, args, context):
+    params = [param.value for param in block.params]
+    args_dict = dict(zip(params, args))
+    ctx = context.enclose_with_args(args_dict)
+    return evaluate(block.body, ctx)
+
 @arg("block", obj.Block)
 @builtin("do $block")
 def do_block(args, context):
@@ -85,14 +91,7 @@ def do_block(args, context):
     if len(block.params) > 0:
         return err("since no arguments are provided, $block of `do $block` must have no parameters")
 
-    ctx = context.enclose()
-    return evaluate(block.body, ctx)
-
-def _run_block(block, args, context):
-    params = [param.value for param in block.params]
-    args_dict = dict(zip(params, args))
-    ctx = context.enclose_with_args(args_dict)
-    return evaluate(block.body, ctx)
+    return _run_block(block, [], context)
 
 @arg("block", obj.Block)
 @arg("args", obj.Collection)
@@ -107,11 +106,7 @@ def do_block_with_args(args, context):
     if len(block.params) != len(b_args):
         return err("the amount of arguments provided in `do $block with $args` should match the number of parameters in the block")
 
-    params = [param.value for param in block.params]
-    args_dictionary = dict(zip(params, b_args))
-
-    ctx = context.enclose_with_args(args_dictionary)
-    return evaluate(block.body, ctx)
+    return _run_block(block, b_args, context)
 
 @arg("block", obj.Block)
 @arg("array", obj.Collection)


### PR DESCRIPTION
The `run $block` and `run $block with $args` builtins have been renamed to `do $block` and `do $block with $args`.