### PR TITLE
Allow trailing commas in array and object literals

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -688,6 +688,11 @@ class Parser(object):
 
         while self.peek_is(token.COMMA):
             self.next()
+            
+            if self.peek_is(end):
+                self.next()
+                return exprs
+            
             self.next()
             exprs.append(self.parse_expr(LOWEST))
 
@@ -708,6 +713,11 @@ class Parser(object):
 
         while self.peek_is(token.COMMA):
             self.next()
+            
+            if self.peek_is(end):
+                self.next()
+                return pairs
+            
             self.next()
             key, val = self.parse_pair()
             pairs[key] = val


### PR DESCRIPTION
Array literals can now have trailing commas, like this:

```r
my_array = [
  1.5,
  56.2,
  8.57,
  9,     # <- this comma is optional
]
```

The same goes for object literals.