### PR TITLE
Throwing

### DIFF
--- a/examples/errors.pluto
+++ b/examples/errors.pluto
@@ -1,11 +1,11 @@
 def throws an error {
-  throw General "An error :)" # throw $tag $message
+  throw GeneralError "An error :)" # throw $tag $message
 }
 
 try {
   throws an error
 } catch (tag) {
-  General => {
+  GeneralError => {
     print "An error ocurred"
   }
 }

--- a/examples/errors.pluto
+++ b/examples/errors.pluto
@@ -1,0 +1,11 @@
+def throws an error {
+  throw General "An error :)" # throw $tag $message
+}
+
+try {
+  throws an error
+} catch (tag) {
+  General => {
+    print "An error ocurred"
+  }
+}

--- a/src/builtin_fns.py
+++ b/src/builtin_fns.py
@@ -36,7 +36,7 @@ def arg(name, expected_type):
                     name,
                     expected_type.t,
                     args[name].type
-                ))
+                ), "TypeError")
 
             return fn(args, context)
         
@@ -102,11 +102,11 @@ def _run_block(block, args, context):
 def do_block(args, context):
     block = args["block"]
 
-    if type(block) != obj.Block:
-        return err("the $block parameter in `do $block` must be of type <block>")
-
     if len(block.params) > 0:
-        return err("since no arguments are provided, $block of `do $block` must have no parameters")
+        return err(
+            "since no arguments are provided, $block of `do $block` must have no parameters",
+            "TypeError"
+        )
 
     return _run_block(block, [], context)
 
@@ -118,11 +118,11 @@ def do_block_with_args(args, context):
     block = args["block"]
     b_args = args["args"].get_elements()
 
-    if type(block) != obj.Block:
-        return err("the $block parameter in `do $block with $args` must be of type <block>")
-
     if len(block.params) != len(b_args):
-        return err("the amount of arguments provided in `do $block with $args` should match the number of parameters in the block")
+        return err(
+            "the amount of arguments provided in `do $block with $args` should match the number of parameters in the block",
+            "TypeError"
+        )
 
     return _run_block(block, b_args, context)
 
@@ -132,9 +132,6 @@ def do_block_with_args(args, context):
 def do_block_on_arg(args, context):
     block = args["block"]
     arg = args["arg"]
-    
-    if type(block) != obj.Block:
-        return err("the $block parameter in `do $block with $args` must be of type <block>")
     
     return _run_block(block, [arg], context)
 
@@ -305,7 +302,7 @@ def index_i_of_array(args, context):
     array = args["array"]
 
     if not i.is_integer() or not i.is_positive() or not int(i.value) < len(array.get_elements()):
-        return err("invalid index: %s" % i)
+        return err("invalid index: %s" % i, "OutOfBoundsError")
 
     return array.get_elements()[int(i.value)]
 
@@ -317,7 +314,7 @@ def key_of_obj(args, context):
     obj = args["obj"]
 
     if key not in obj.pairs.keys():
-        return err("key %s not found" % key)
+        return err("key %s not found" % key, "NotFoundError")
 
     return obj.pairs[key]
 
@@ -354,10 +351,10 @@ def start_to_end(args, context):
     end = args["end"]
 
     if not start.is_integer():
-        return err("$start in `$start to $end` must be an integer")
+        return err("$start in `$start to $end` must be an integer", "TypeError")
 
     if not end.is_integer():
-        return err("$end in `$start to $end` must be an integer")
+        return err("$end in `$start to $end` must be an integer", "TypeError")
 
     s_val = int(start.value)
     e_val = int(end.value)
@@ -382,7 +379,7 @@ def format_string_with_args(args, context):
     try:
         return obj.String(fmt % items)
     except TypeError:
-        return err("Wrong number of arguments to format `%s`" % fmt)
+        return err("Wrong number of arguments to format `%s`" % fmt, "TypeError")
 
 @builtin
 @pattern("printf $format with $args")
@@ -395,7 +392,7 @@ def printf_format_with_args(args, context):
     try:
         print(obj.String(fmt % items))
     except TypeError:
-        return err("Wrong number of arguments to format `%s`" % fmt)
+        return err("Wrong number of arguments to format `%s`" % fmt, "TypeError")
 
     return NULL
 

--- a/src/builtin_fns.py
+++ b/src/builtin_fns.py
@@ -83,6 +83,13 @@ def input_with_prompt_prompt(args, context):
     except (KeyboardInterrupt, EOFError):
         return NULL
 
+@builtin
+@pattern("throw $tag $message")
+@arg("tag", obj.String)
+@arg("message", obj.String)
+def throw_tag_message(args, context):
+    return err(args["message"], args["tag"])
+
 def _run_block(block, args, context):
     params = [param.value for param in block.params]
     args_dict = dict(zip(params, args))

--- a/src/lib/prelude.pluto
+++ b/src/lib/prelude.pluto
@@ -1,3 +1,13 @@
+### Constants
+
+# Error types
+GeneralError = "err-general"
+TypeError    = "err-types"
+IOError      = "err-io"
+
+
+### Functions
+
 # Misc
 def $obj is truthy {
   if (obj) { true } else { false }

--- a/src/lib/prelude.pluto
+++ b/src/lib/prelude.pluto
@@ -1,9 +1,13 @@
 ### Constants
 
 # Error types
-GeneralError = "GeneralError"
-TypeError    = "TypeError"
-IOError      = "IOError"
+GeneralError        = "GeneralError"
+TypeError           = "TypeError"
+IOError             = "IOError"
+OutOfBoundsError    = "OutOfBoundsError"
+NotFoundError       = "NotFoundError"
+SyntaxError         = "SyntaxError"
+NotImplementedError = "NotImplementedError"
 
 
 ### Functions

--- a/src/lib/prelude.pluto
+++ b/src/lib/prelude.pluto
@@ -1,9 +1,9 @@
 ### Constants
 
 # Error types
-GeneralError = "err-general"
-TypeError    = "err-types"
-IOError      = "err-io"
+GeneralError = "GeneralError"
+TypeError    = "TypeError"
+IOError      = "IOError"
 
 
 ### Functions

--- a/src/obj.py
+++ b/src/obj.py
@@ -53,14 +53,15 @@ class Error(InternalObject):
     t = ERROR
 
     """represents an error thrown in execution"""
-    def __init__(self, msg):
+    def __init__(self, msg, tag="GeneralError"):
         self.type = ERROR
         self.msg = msg
+        self.tag = tag
 
     __eq__ = compare("msg")
 
     def __str__(self):
-        return "ERROR: %s" % self.msg
+        return "%s: %s" % (tag, self.msg)
 
 
 class ReturnValue(InternalObject):

--- a/src/obj.py
+++ b/src/obj.py
@@ -61,7 +61,7 @@ class Error(InternalObject):
     __eq__ = compare("msg")
 
     def __str__(self):
-        return "%s: %s" % (tag, self.msg)
+        return "%s: %s" % (self.tag, self.msg)
 
 
 class ReturnValue(InternalObject):


### PR DESCRIPTION
You can now throw errors with the `throw $tag $message` function:

```java
throw $NotFoundError "Something couldn't be found!"
```

The default error tags are the following (defined in Prelude):

```
GeneralError       
TypeError          
IOError            
OutOfBoundsError   
NotFoundError      
SyntaxError        
NotImplementedError
```

But, of course, any string can be used for a tag or message.